### PR TITLE
Fix AWS CUR column naming to preserve category prefixes

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -82,14 +82,14 @@ def main():
     
     # Run unit tests
     if not run_command(
-        ["python", "-m", "pytest", "tests/unit/", "-v", "--tb=short"],
+        ["python3", "-m", "pytest", "tests/unit/", "-v", "--tb=short"],
         "Running unit tests"
     ):
         all_passed = False
     
     # Run integration tests
     if not run_command(
-        ["python", "-m", "pytest", "tests/integration/", "-v", "--tb=short"],
+        ["python3", "-m", "pytest", "tests/integration/", "-v", "--tb=short"],
         "Running integration tests"
     ):
         all_passed = False
@@ -97,7 +97,7 @@ def main():
     # Run all tests with coverage (optional)
     if "--coverage" in sys.argv:
         if not run_command(
-            ["python", "-m", "pytest", "--cov=src", "--cov-report=term-missing"],
+            ["python3", "-m", "pytest", "--cov=src", "--cov-report=term-missing"],
             "Running tests with coverage"
         ):
             all_passed = False
@@ -106,13 +106,13 @@ def main():
     if "--quality" in sys.argv:
         # Black formatting check
         run_command(
-            ["python", "-m", "black", "--check", "src/", "tests/"],
+            ["python3", "-m", "black", "--check", "src/", "tests/"],
             "Checking code formatting (black)"
         )
         
         # Ruff linting
         run_command(
-            ["python", "-m", "ruff", "check", "src/", "tests/"],
+            ["python3", "-m", "ruff", "check", "src/", "tests/"],
             "Running linter (ruff)"
         )
     

--- a/src/pipelines/aws/pipeline.py
+++ b/src/pipelines/aws/pipeline.py
@@ -234,13 +234,13 @@ def read_csv_file(s3_client, bucket: str, key: str, aws_creds: Dict[str, Any]) -
         # Yield records as dictionaries
         for row in result:
             record = dict(zip(columns, row))
-            # Clean up column names (remove any prefixes)
+            # Clean up column names (replace / with _)
             cleaned_record = {}
             for col, val in record.items():
                 # Handle different column naming conventions
                 if '/' in col:
-                    # Remove prefix (e.g., "lineItem/UsageAmount" -> "UsageAmount")
-                    clean_col = col.split('/')[-1]
+                    # Replace / with _ (e.g., "lineItem/UnblendedCost" -> "lineItem_UnblendedCost")
+                    clean_col = col.replace('/', '_')
                 else:
                     clean_col = col
                 cleaned_record[clean_col] = val
@@ -279,7 +279,17 @@ def read_parquet_file(s3_client, bucket: str, key: str, aws_creds: Dict[str, Any
         # Yield records as dictionaries
         for row in result:
             record = dict(zip(columns, row))
-            yield record
+            # Clean up column names (replace / with _)
+            cleaned_record = {}
+            for col, val in record.items():
+                # Handle different column naming conventions
+                if '/' in col:
+                    # Replace / with _ (e.g., "lineItem/UnblendedCost" -> "lineItem_UnblendedCost")
+                    clean_col = col.replace('/', '_')
+                else:
+                    clean_col = col
+                cleaned_record[clean_col] = val
+            yield cleaned_record
             
     finally:
         conn.close()

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -49,6 +49,30 @@ class TestManifestFile:
         
         assert manifest.report_keys == ["file1.csv.gz", "file2.csv.gz"]
     
+    def test_report_keys_v2_with_data_files(self):
+        """Test report_keys property with CUR v2 dataFiles."""
+        manifest = ManifestFile(
+            bucket="test-bucket",
+            key="test-key",
+            billing_period="2024-01",
+            version="v2",
+            data={"dataFiles": ["s3://bucket/file1.parquet", "s3://bucket/file2.parquet"]}
+        )
+        
+        assert manifest.report_keys == ["s3://bucket/file1.parquet", "s3://bucket/file2.parquet"]
+    
+    def test_report_keys_v2_empty_when_no_data_files(self):
+        """Test report_keys property returns empty list when v2 manifest has no dataFiles."""
+        manifest = ManifestFile(
+            bucket="test-bucket",
+            key="test-key", 
+            billing_period="2024-01",
+            version="v2",
+            data={"reportKeys": ["file1.parquet", "file2.parquet"]}  # v2 should ignore reportKeys
+        )
+        
+        assert manifest.report_keys == []  # v2 only looks for dataFiles
+    
     def test_assembly_id(self):
         """Test assembly_id property."""
         manifest = ManifestFile(


### PR DESCRIPTION
## Summary
- Replace '/' with '_' in AWS CUR column names instead of removing prefixes entirely
- Add consistent column cleaning logic for both CSV and parquet files
- Add comprehensive CUR v2 test coverage for dataFiles vs reportKeys behavior
- Fix test runner to use python3 instead of python

## Problem
The previous column cleaning logic was removing AWS CUR category prefixes entirely:
- `"lineItem/UnblendedCost"` → `"UnblendedCost"` ❌
- `"reservation/UnblendedCost"` → `"UnblendedCost"` ❌ (collision\!)

This caused:
1. **Column name collisions** between different categories
2. **Loss of important context** about data categorization  
3. **FOCUS compatibility issues** for future transformations

## Solution
Now preserves all information by replacing `/` with `_`:
- `"lineItem/UnblendedCost"` → `"lineItem_UnblendedCost"` ✅
- `"reservation/UnblendedCost"` → `"reservation_UnblendedCost"` ✅

## Changes
- **src/pipelines/aws/pipeline.py**: Updated both `read_csv_file()` and `read_parquet_file()` to use `col.replace('/', '_')`
- **tests/unit/test_manifest.py**: Added 2 new tests for CUR v2 `dataFiles` vs `reportKeys` behavior  
- **run_tests.py**: Fixed to use `python3` instead of `python`

## Test plan
- [x] All 23 unit tests pass
- [x] All 13 integration tests pass  
- [x] New CUR v2 manifest tests validate proper behavior
- [x] Column naming preserves AWS CUR category prefixes (lineItem, reservation, savingsPlans, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)